### PR TITLE
"incubator" carpentry setting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
 # incubator: The Carpentries Incubator
-carpentry: cp
+carpentry: incubator
 
 # Overall title for pages.
 title: Lesson Title

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@
 # dc: Data Carpentry
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
+# incubator: The Carpentries Incubator
 carpentry: cp
 
 # Overall title for pages.


### PR DESCRIPTION
1. add a comment line to list "incubator" as a valid option for the `carpentry` field
2. adjust the default value for `carpentry` to be "incubator"

Perhaps you do not want to do the second one? But my guess is that the copyright statement etc that comes with the Incubator styling will be preferable to most people using this template.