### PR TITLE
fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ complete the initial configuration of a new lesson repository built from this te
       you should ensure that the copyright information 
       provided in the license file is accurate for your project.
 1. **Update this README with 
-   [relevant information about your lesson](https://carpentries.github.io/lesson-development-training/26-external.html#readme)**
+   [relevant information about your lesson](https://carpentries.github.io/lesson-development-training/collaborating-newcomers.html#readme)**
    and delete this section.
 
 [workbench]: https://carpentries.github.io/sandpaper-docs/


### PR DESCRIPTION
This will fix the link to the CLDT a la https://github.com/carpentries/workbench-template-rmd/pull/56

ht @tobyhodges 