### PR TITLE
fix broken link for Pandoc documentation

### DIFF
--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -20,7 +20,7 @@ exercises: 2
 ## Introduction
 
 This is a lesson created via The Carpentries Workbench. It is written in
-[Pandoc-flavored Markdown](https://pandoc.org/MANUAL.txt) for static files and
+[Pandoc-flavored Markdown](https://pandoc.org/MANUAL.html) for static files and
 [R Markdown][r-markdown] for dynamic files that can render code into output. 
 Please refer to the [Introduction to The Carpentries 
 Workbench](https://carpentries.github.io/sandpaper-docs/) for full documentation.


### PR DESCRIPTION
The link in the introduction episode template to the Pandoc manual 404s, as they don't (any more, at least) have a `.txt` version of this on their website. This PR updates that to the HTML version, which resolves correctly.