### PR TITLE
[github actions] explicit installation of R in ubuntu-latest (instead of version pinning)

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,10 +21,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-
-    # 2024-10-01: ubuntu-latest is now 24.04 and R is not installed by default in the runner image
-    # pin to 22.04 for now
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       checks: write
       contents: write
@@ -41,7 +38,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          install-r: false
+          install-r: true
 
       - name: "Set up Pandoc"
         uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION

Hi,

I suggest to trigger an explicit installation of R via the respective R setup action instead of pinning an old Ubuntu.

Works for my derived carpentries.

Best,
Martin
